### PR TITLE
fix(deps): migrate to device_frame_plus and update freezed to v3

### DIFF
--- a/lib/device_preview_plus.dart
+++ b/lib/device_preview_plus.dart
@@ -1,4 +1,4 @@
-export 'package:device_frame/device_frame.dart';
+export 'package:device_frame_plus/device_frame_plus.dart';
 
 export 'src/device_preview.dart';
 export 'src/locales/default_locales.dart';

--- a/lib/src/device_preview.dart
+++ b/lib/src/device_preview.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-import 'package:device_frame/device_frame.dart';
+import 'package:device_frame_plus/device_frame_plus.dart';
 import 'package:device_preview_plus/src/state/state.dart';
 import 'package:device_preview_plus/src/state/store.dart';
 import 'package:device_preview_plus/src/storage/storage.dart';

--- a/lib/src/utilities/screenshot.dart
+++ b/lib/src/utilities/screenshot.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:device_frame/device_frame.dart';
+import 'package:device_frame_plus/device_frame_plus.dart';
 
 /// A screenshot from a preview.
 class DeviceScreenshot {

--- a/lib/src/views/tool_panel/sections/subsections/device_model.dart
+++ b/lib/src/views/tool_panel/sections/subsections/device_model.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart';
-import 'package:device_frame/device_frame.dart';
+import 'package:device_frame_plus/device_frame_plus.dart';
 import 'package:device_preview_plus/src/state/store.dart';
 import 'package:device_preview_plus/src/views/tool_panel/widgets/device_type_icon.dart';
 import 'package:device_preview_plus/src/views/tool_panel/widgets/target_platform_icon.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   provider: ^6.1.2
-  device_frame: ^1.2.0
-  freezed_annotation: ^2.4.4
+  device_frame_plus: ^1.3.0
+  freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   shared_preferences: ^2.5.2
   collection: ^1.18.0
@@ -25,5 +25,5 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: 5.0.0
   build_runner: 2.4.15
-  freezed: 2.5.8
+  freezed: 3.0.3
   json_serializable: 6.9.4


### PR DESCRIPTION
This is a similar PR to your own, however I changed device_frame to device_frame_plus, which has updated freezed.

| Package | Type | Update | Change |
| --- | --- | ---| --- |
device_frame_plus | (https://github.com/StorybookToolkit/device_frame_plus) | dependencies | major | add 
freezed | (https://redirect.github.com/rrousselGit/freezed) | dev_dependencies | major | `2.5.8` -> `3.0.3`
freezed_annotation | (https://redirect.github.com/rrousselGit/freezed) | dependencies | major | `^2.4.4` -> `^3.0.0`
