### PR TITLE
fix(example): only enabled in debug mode

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,7 +9,7 @@ import 'custom_plugin.dart';
 void main() {
   runApp(
     DevicePreview(
-      enabled: kDebugMode?true:false,
+      enabled: kDebugMode,
       tools: const [...DevicePreview.defaultTools, CustomPlugin()],
       builder: (context) => const BasicApp(),
     ),


### PR DESCRIPTION
with this small change device preview is enabled only in debug mode, avoiding having to create additional code to carry out checks when downloading the plugin
